### PR TITLE
Added an ignore list option to the `readdir()` func

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,11 @@ var fs = require('fs')
 var p = require('path')
 
 // how to know when you are done?
-function readdir(path, callback) {
+function readdir(path, ignores, callback) {
+  if (typeof ignores == 'function') {
+    callback = ignores
+    ignores  = null
+  }
   var list = []
 
   fs.readdir(path, function (err, files) {
@@ -17,13 +21,17 @@ function readdir(path, callback) {
     }
 
     files.forEach(function (file) {
+      if (ignores != null && ignores.indexOf(file) > -1){
+        return pending -= 1
+      }
+
       fs.stat(p.join(path, file), function (err, stats) {
         if (err) {
           return callback(err)
         }
 
         if (stats.isDirectory()) {
-          files = readdir(p.join(path, file), function (err, res) {
+          files = readdir(p.join(path, file), ignores, function (err, res) {
             list = list.concat(res)
             pending -= 1
             if (!pending) {

--- a/test/recursive-raddir-test.js
+++ b/test/recursive-raddir-test.js
@@ -14,4 +14,19 @@ describe('readdir', function() {
       done()
     })
   })
+  it('ignores the files listed in the ignores array', function (done) {
+    var notExpectedFiles = [
+      __dirname + '/testdir/d.txt',
+      __dirname + '/testdir/a/beans'
+    ]
+
+    readdir(__dirname + '/testdir', ['d.txt', 'beans'], function(err, list) {
+      assert.ifError(err);
+      list.forEach(function(file) {
+        assert.equal(notExpectedFiles.indexOf(file), -1,
+          'Failed to ignore file "'+ file +'".')
+      })
+      done()
+    })
+  })
 })


### PR DESCRIPTION
`readdir()` now takes a list as the 2nd argument. The `ignores`
option can be a list, `null`, or a function. Supporting both
`readdir(path, callback)` and `readdir(path, ignores, callback)` syntax.

The `ignores` list is just a simple string list, any type of advanced
regex is not currently checked.
