### PR TITLE
Fix readme rendering on NPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,4 @@ recursive('some/path', ['foo.cs', 'bar.html'], function (err, files) {
 });
 
 It doesn't do globbing, just a simple `indexOf` check against the filename.
+```


### PR DESCRIPTION
The last example missed the three closing backquotes. Therefore it was not correctly rendered though the NPM website Markdown engine.

This fix adds the missing backquotes, so the rendering should now be fine.
