### PR TITLE
Change stat to lstat.

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ function readdir(path, ignores, callback) {
         }
       }
 
-      fs.stat(p.join(path, file), function (err, stats) {
+      fs.lstat(p.join(path, file), function (err, stats) {
         if (err) {
           return callback(err)
         }


### PR DESCRIPTION
Fixes an issue when a walk encounters symbolic links, using stat() they
appear as undefined in the resulting array.