### PR TITLE
Allow ignoring directories using non-negated string matchers

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,8 @@ var minimatch = require('minimatch')
 
 function patternMatcher(pattern) {
   return function(path, stats) {
-    return stats.isFile() && minimatch(path, pattern, {matchBase: true})
+    var minimatcher = new minimatch.Minimatch(pattern, {matchBase: true})
+    return (!minimatcher.negate || stats.isFile()) && minimatcher.match(path)
   }
 }
 

--- a/test/recursive-readdir-test.js
+++ b/test/recursive-readdir-test.js
@@ -41,6 +41,21 @@ describe('readdir', function() {
     })
   })
 
+  it('ignores the directories listed in the ignores array', function(done) {
+    var notExpectedFiles = getAbsolutePaths([
+      '/testdir/a/a', '/testdir/a/beans'
+    ])
+
+    readdir(p.join(__dirname, 'testdir'), ['**/testdir/a'], function(err, list) {
+      assert.ifError(err)
+      list.forEach(function(file) {
+        assert.equal(notExpectedFiles.indexOf(file), -1,
+          'Failed to ignore file "' + file + '".')
+      })
+      done()
+    })
+  })
+
   it('supports ignoring files with just basename globbing', function(done) {
     var notExpectedFiles = getAbsolutePaths([
       '/testdir/d.txt', '/testdir/a/beans'


### PR DESCRIPTION
This fixes a problem created as a side effect of #20, while still solving the original issue, #16. It works by allowing string-based matchers to ignore directories, except when those matchers are negated (preceded by a `!`), in which case they only apply to files.

Let me know if this is something you want or not. After you decide whether to accept or reject this PR, I'd appreciate it if you'd cut a release so that we can use some of the recently added features from this library in Metalsmith.

If you decide to reject this PR though, the release would definitely have to be v2.0 as per SemVer, since you'd be removing the ability to ignore entire directories with string matchers. Even with this PR there have technically been breaking changes in `recursive-readdir`'s behavior, but you could probably get away with calling them a minor fix in that case, since `recursive-readdir`'s previous handling of negated matchers wasn't particularly useful anyway.