### PR TITLE
Ignore file if fs.stat returns an error

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ function readdir(path, ignores, callback) {
 
     files.forEach(function(file) {
       var filePath = p.join(path, file)
-      fs.stat(filePath, function(_err, stats) {
+      fs.lstat(filePath, function(_err, stats) {
         if (_err) {
           return null
         }

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ function readdir(path, ignores, callback) {
       var filePath = p.join(path, file)
       fs.stat(filePath, function(_err, stats) {
         if (_err) {
-          return callback(_err)
+          return null
         }
 
         if (ignores.some(function(matcher) { return matcher(filePath, stats) })) {


### PR DESCRIPTION
Currently, if `fs.stat` fails for one specific file, the complete `recursive-readdir` operation is aborted with an error.

I think we should change this behavior and just ignore the specific failing file instead of letting `recursive-readdir` completely fail.

Background:
In my case it is happening sometimes that a file is deleted in the time between the `fs.readdir` and the `fs.stat` operation of `recursive-readdir`. In this case `fs.stat` fails with `ENOENT` and makes `recursive-readdir` completely fail.
