### PR TITLE
Fix deprecated minimatch warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "node": ">=0.6.6"
   },
   "dependencies": {
-    "minimatch": "0.3.0"
+    "minimatch": "^3.0.2"
   },
   "devDependencies": {
     "mocha": "1.14.0"


### PR DESCRIPTION
Hi  there,

I got the following warning when your package has been installed:

```
npm WARN deprecated minimatch@0.3.0: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
```

Please merge this pull request to update minimatch to the newest version.

Thanks,
Dong