### PR TITLE
fix: vulnerability via minimatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "node": ">=0.6.6"
   },
   "dependencies": {
-    "minimatch": "0.3.0"
+    "minimatch": "3.0.2"
   },
   "devDependencies": {
     "mocha": "1.14.0"


### PR DESCRIPTION
Hey, I know you have an open (failing) PR for this fix already, but I saw that it was [bailing](https://travis-ci.org/jergason/recursive-readdir/jobs/139088130) on the old versions of node that you test again (0.8 and 0.6) (because the package was using a `^`). 

So I've just created the same PR but this time pinned to the latest release of minimatch (so it should pass). Hope you're happy to merge and release.

Thanks so much.