### PR TITLE
Return a promise if no callback specified

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,10 +18,24 @@ function toMatcherFunction(ignoreEntry) {
 }
 
 function readdir(path, ignores, callback) {
+
   if (typeof ignores == 'function') {
     callback = ignores
     ignores = []
   }
+
+  if (!callback) {
+    return new Promise(function (resolve, reject) {
+      readdir(path, ignores || [], function (err, data) {
+        if (err) {
+          reject(err)
+        } else {
+          resolve(data)
+        }
+      })
+    })
+  }
+
   ignores = ignores.map(toMatcherFunction)
 
   var list = []

--- a/test/recursive-readdir-test.js
+++ b/test/recursive-readdir-test.js
@@ -277,17 +277,22 @@ describe('readdir', function() {
     })
   })
 
-  it('works with promises', function(done) {
-    var expectedFiles = getAbsolutePaths([
-      '/testdir/a/a', '/testdir/a/beans',
-      '/testdir/b/123', '/testdir/b/b/hurp-durp',
-      '/testdir/c.txt', '/testdir/d.txt'
-    ])
+  if (!global.Promise) {
+    console.log("Native Promise not supported - skipping tests")
+  } else {
+    it('works with promises', function(done) {
 
-    readdir(p.join(__dirname, 'testdir'))
-    .then(function(list) {
-      assert.deepEqual(list.sort(), expectedFiles.sort())
-      done()
+      var expectedFiles = getAbsolutePaths([
+        '/testdir/a/a', '/testdir/a/beans',
+        '/testdir/b/123', '/testdir/b/b/hurp-durp',
+        '/testdir/c.txt', '/testdir/d.txt'
+      ])
+
+      readdir(p.join(__dirname, 'testdir'))
+      .then(function(list) {
+        assert.deepEqual(list.sort(), expectedFiles.sort())
+        done()
+      })
     })
-  })
+  }
 })

--- a/test/recursive-readdir-test.js
+++ b/test/recursive-readdir-test.js
@@ -276,4 +276,18 @@ describe('readdir', function() {
       done()
     })
   })
+
+  it('works with promises', function(done) {
+    var expectedFiles = getAbsolutePaths([
+      '/testdir/a/a', '/testdir/a/beans',
+      '/testdir/b/123', '/testdir/b/b/hurp-durp',
+      '/testdir/c.txt', '/testdir/d.txt'
+    ])
+
+    readdir(p.join(__dirname, 'testdir'))
+    .then(function(list) {
+      assert.deepEqual(list.sort(), expectedFiles.sort())
+      done()
+    })
+  })
 })


### PR DESCRIPTION
Assumes native promises are available (or have been polyfilled). If they aren't, then you still need to supply a callback function.
