### PR TITLE
Fixing issue with broken symlinks

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,23 @@ function readdir(path, ignores, callback) {
       var filePath = p.join(path, file)
       fs.stat(filePath, function(_err, stats) {
         if (_err) {
+          if (_err.code == 'ENOENT') {
+            fs.lstat(filePath, function(_lserr, stats) {
+              if (_lserr) {
+                return callback(_lserr)
+              }
+
+              if (ignores.some(function(matcher) { return matcher(filePath, stats) })) {
+                pending -= 1
+                if (!pending) {
+                  return callback(null, list)
+                }
+                return null
+              }
+              return callback(_err)
+            })
+            return null
+          }
           return callback(_err)
         }
 

--- a/test/recursive-readdir-test.js
+++ b/test/recursive-readdir-test.js
@@ -240,6 +240,22 @@ describe('readdir', function() {
         done()
       })
     })
+
+    it('does not fail on broken symlink if it is ignored', function(done) {
+      var expectedFiles = getAbsolutePaths([
+        '/testbrokensymlink/foo.bar'
+      ])
+      function ignoreFunction(path, stats) {
+        return stats.isSymbolicLink();
+      }
+
+      readdir(p.join(__dirname, 'testbrokensymlink'), [ignoreFunction], function(err, list) {
+        assert.ifError(err)
+        assert.deepEqual(list.sort(), expectedFiles,
+                         'Failed to find expected files.')
+        done()
+      })
+    })
   })
 
   it('works when there are no files to report except ignored files', function(done) {

--- a/test/testbrokensymlink/brokenlink
+++ b/test/testbrokensymlink/brokenlink
@@ -1,0 +1,1 @@
+badlink


### PR DESCRIPTION
Problem:
When traversing a directory containig broken symbolic links, said links
throw error before we have a chance to ignore them, which we might want
to.

Solution:
When encountering error code `ENOENT` make `lstat` call which doesn't
fail on broken links due to not following them. It is up to the user
then to check if he needs to ignore this particular link via ignore
function or pattern.

Fixes #42