### PR TITLE
Migrate to ES2015 Syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,23 +10,19 @@ function patternMatcher(pattern) {
 }
 
 function toMatcherFunction(ignoreEntry) {
-  return (typeof ignoreEntry == 'function') ? ignoreEntry : patternMatcher(ignoreEntry)
+  return typeof ignoreEntry == 'function' ? ignoreEntry : patternMatcher(ignoreEntry)
 }
 
 function readdir(path, ignores, callback) {
-  if (typeof ignores == 'function') {
+  if(typeof ignores == 'function') {
     callback = ignores
     ignores = []
   }
 
-  if (!callback) {
+  if(!callback) {
     return new Promise((resolve, reject) => {
       readdir(path, ignores || [], (err, data) => {
-        if (err) {
-          reject(err)
-        } else {
-          resolve(data)
-        }
+        if (err) { reject(err) } else { resolve(data) }
       })
     })
   }
@@ -36,12 +32,10 @@ function readdir(path, ignores, callback) {
   let list = []
 
   fs.readdir(path, (err, files) => {
-    if (err) {
-      return callback(err)
-    }
+    if(err) { return callback(err) }
 
     let pending = files.length
-    if (!pending) {
+    if(!pending) {
       // we are done, woop woop
       return callback(null, list)
     }
@@ -49,40 +43,26 @@ function readdir(path, ignores, callback) {
     for(let i = 0; i < pending; i++) {
       let filePath = p.join(path, files[i])
       fs.stat(filePath, (_err, stats) => {
-        if (_err) {
-          return callback(_err)
-        }
+        if(_err) { return callback(_err) }
 
-        if (
-          ignores.some(matcher => {
-            return matcher(filePath, stats)
-          })
-        ) {
+        if(ignores.some(matcher => { matcher(filePath, stats) })) {
           pending -= 1
-          if (!pending) {
-            return callback(null, list)
-          }
+          if (!pending) { return callback(null, list) }
           return null
         }
 
-        if (stats.isDirectory()) {
+        if(stats.isDirectory()) {
           readdir(filePath, ignores, (__err, res) => {
-            if (__err) {
-              return callback(__err)
-            }
+            if(__err) { return callback(__err) }
 
             list = list.concat(res)
             pending -= 1
-            if (!pending) {
-              return callback(null, list)
-            }
+            if(!pending) { return callback(null, list) }
           })
         } else {
           list.push(filePath)
           pending -= 1
-          if (!pending) {
-            return callback(null, list)
-          }
+          if(!pending) { return callback(null, list) }
         }
       })
     }


### PR DESCRIPTION
General update to ES2015 syntax:
 - Remove ;
 - Change function() { to () => {
 - Change foreach to a traditional for (for performance purpose only)