### PR TITLE
Only include index.js when in published npm module

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "url": "git://github.com/jergason/recursive-readdir.git"
   },
   "main": "./index.js",
+  "files": [
+    "index.js"
+  ],
   "scripts": {
     "test": "mocha test/"
   },


### PR DESCRIPTION
Thanks for your work with this module 🙏 

I noticed that the `test` folder is being published with this npm module - this PR corrects that:
![image](https://user-images.githubusercontent.com/13087421/58022593-5e327800-7b40-11e9-9276-b9a38a085e0c.png)
