### PR TITLE
Update minimatch@3.0.4 to minimatch@3.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "node": ">=6.0.0"
   },
   "dependencies": {
-    "minimatch": "3.0.4"
+    "minimatch": "3.0.5"
   },
   "devDependencies": {
     "mocha": "6.1.4"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "node": ">=6.0.0"
   },
   "dependencies": {
-    "minimatch": "3.0.5"
+    "minimatch": "^3.0.5"
   },
   "devDependencies": {
     "mocha": "6.1.4"


### PR DESCRIPTION
High severity vulnerability in minimatch@3.0.4, update to 3.0.5 per https://github.com/jergason/recursive-readdir/issues/83

Vulnerability description: 
minimatch package versions before 3.0.5 are vulnerable to Regular Expression Denial of Service (ReDoS). It\'s possible to cause a denial of service when calling function braceExpand (The regex /\\{.*\\}/ is vulnerable and can be exploited).

FWIW: Added minimatch@3.0.5 as resolution to package.json file, recursive-readdir continues to work with this update.